### PR TITLE
feat/default pic quality

### DIFF
--- a/app/screens/PostAuthentication/DataCollection.tsx
+++ b/app/screens/PostAuthentication/DataCollection.tsx
@@ -260,7 +260,7 @@ const DataCollection: React.FC<Props> = ({navigation}) => {
       const response = await launchCamera({
         mediaType: 'photo',
         includeBase64: false,
-        quality: 0.1,
+        quality: 1.0,
         saveToPhotos: true,
       });
       if (response.didCancel) {


### PR DESCRIPTION
- increased pic quality
- for some reason when the pic quality is default i.e 1, the app crashes less often. probably when its 0.1 or something some image processing is happening and could be the reason for app crash.